### PR TITLE
Acronym

### DIFF
--- a/ruby/acronym/.exercism/metadata.json
+++ b/ruby/acronym/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"ruby","exercise":"acronym","id":"631c81f62bc543a59c9a677deaa18253","url":"https://exercism.io/my/solutions/631c81f62bc543a59c9a677deaa18253","handle":"n-flint","is_requester":true,"auto_approve":false}

--- a/ruby/acronym/README.md
+++ b/ruby/acronym/README.md
@@ -1,0 +1,38 @@
+# Acronym
+
+Convert a phrase to its acronym.
+
+Techies love their TLA (Three Letter Acronyms)!
+
+Help generate some jargon by writing a program that converts a long name
+like Portable Network Graphics to its acronym (PNG).
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby acronym_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride acronym_test.rb
+
+
+## Source
+
+Julien Vanier [https://github.com/monkbroc](https://github.com/monkbroc)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/ruby/acronym/acronym.rb
+++ b/ruby/acronym/acronym.rb
@@ -1,0 +1,9 @@
+
+class Acronym
+
+  def self.abbreviate(input_string)
+    input_string.split.map do |word|
+      word[0].upcase.split('-')
+    end.join
+  end
+end

--- a/ruby/acronym/acronym_test.rb
+++ b/ruby/acronym/acronym_test.rb
@@ -1,0 +1,40 @@
+require 'minitest/autorun'
+require_relative 'acronym'
+
+# Common test data version: 1.7.0 cacf1f1
+class AcronymTest < Minitest::Test
+  def test_basic
+    # skip
+    assert_equal "PNG", Acronym.abbreviate('Portable Network Graphics')
+  end
+
+  def test_lowercase_words
+    # skip
+    assert_equal "ROR", Acronym.abbreviate('Ruby on Rails')
+  end
+
+  def test_punctuation
+    # skip
+    assert_equal "FIFO", Acronym.abbreviate('First In, First Out')
+  end
+
+  def test_all_caps_word
+    # skip
+    assert_equal "GIMP", Acronym.abbreviate('GNU Image Manipulation Program')
+  end
+
+  def test_punctuation_without_whitespace
+    # skip
+    assert_equal "CMOS", Acronym.abbreviate('Complementary metal-oxide semiconductor')
+  end
+
+  def test_very_long_abbreviation
+    # skip
+    assert_equal "ROTFLSHTMDCOALM", Acronym.abbreviate('Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me')
+  end
+
+  def test_consecutive_delimiters
+    # skip
+    assert_equal "SIMUFTA", Acronym.abbreviate('Something - I made up from thin air')
+  end
+end


### PR DESCRIPTION
Convert a phrase to its acronym.

Techies love their TLA (Three Letter Acronyms)!

Help generate some jargon by writing a program that converts a long name like Portable Network Graphics to its acronym (PNG).