### PR TITLE
Word Count WIP

### DIFF
--- a/ruby/word-count/.exercism/metadata.json
+++ b/ruby/word-count/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"ruby","exercise":"word-count","id":"221f6e90aa0542b8a551557684364542","url":"https://exercism.io/my/solutions/221f6e90aa0542b8a551557684364542","handle":"n-flint","is_requester":true,"auto_approve":false}

--- a/ruby/word-count/README.md
+++ b/ruby/word-count/README.md
@@ -1,0 +1,42 @@
+# Word Count
+
+Given a phrase, count the occurrences of each word in that phrase.
+
+For example for the input `"olly olly in come free"`
+
+```text
+olly: 2
+in: 1
+come: 1
+free: 1
+```
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby word_count_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride word_count_test.rb
+
+
+## Source
+
+This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/ruby/word-count/word_count.rb
+++ b/ruby/word-count/word_count.rb
@@ -1,14 +1,13 @@
 class Phrase
 
   def initialize(phrase)
-    @phrase = phrase
+    @phrase = phrase.gsub(/[!@#$%^&*()+=",.?:;]/, ' ').downcase
   end
 
   def word_count
     who = {}
     @phrase.split().each do |word|
-      # this breaks as soon as it hits a comma. It counts the @phrase as one word. Maybe a helper method to make sure the phrase is set before entering?
-      who[word] = @phrase.scan(/(?=#{word})/).count
+      who[word] = @phrase.scan(/\b#{word}\b/).count
     end
     who
   end

--- a/ruby/word-count/word_count.rb
+++ b/ruby/word-count/word_count.rb
@@ -1,0 +1,15 @@
+class Phrase
+
+  def initialize(phrase)
+    @phrase = phrase
+  end
+
+  def word_count
+    who = {}
+    @phrase.split().each do |word|
+      # this breaks as soon as it hits a comma. It counts the @phrase as one word. Maybe a helper method to make sure the phrase is set before entering?
+      who[word] = @phrase.scan(/(?=#{word})/).count
+    end
+    who
+  end
+end

--- a/ruby/word-count/word_count_test.rb
+++ b/ruby/word-count/word_count_test.rb
@@ -1,0 +1,82 @@
+require 'minitest/autorun'
+require_relative 'word_count'
+
+# Common test data version: 1.2.0 77623ec
+class WordCountTest < Minitest::Test
+  def test_count_one_word
+    # skip
+    phrase = Phrase.new("word")
+    counts = {"word"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_count_one_of_each_word
+    # skip
+    phrase = Phrase.new("one of each")
+    counts = {"one"=>1, "of"=>1, "each"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_multiple_occurrences_of_a_word
+    # skip
+    phrase = Phrase.new("one fish two fish red fish blue fish")
+    counts = {"one"=>1, "fish"=>4, "two"=>1, "red"=>1, "blue"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_handles_cramped_lists
+    skip
+    phrase = Phrase.new("one,two,three")
+    counts = {"one"=>1, "two"=>1, "three"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_handles_expanded_lists
+    skip
+    phrase = Phrase.new("one,\ntwo,\nthree")
+    counts = {"one"=>1, "two"=>1, "three"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_ignore_punctuation
+    skip
+    phrase = Phrase.new("car: carpet as java: javascript!!&@$%^&")
+    counts = {"car"=>1, "carpet"=>1, "as"=>1, "java"=>1, "javascript"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_include_numbers
+    skip
+    phrase = Phrase.new("testing, 1, 2 testing")
+    counts = {"testing"=>2, "1"=>1, "2"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_normalize_case
+    skip
+    phrase = Phrase.new("go Go GO Stop stop")
+    counts = {"go"=>3, "stop"=>2}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_with_apostrophes
+    skip
+    phrase = Phrase.new("First: don't laugh. Then: don't cry.")
+    counts = {"first"=>1, "don't"=>2, "laugh"=>1, "then"=>1, "cry"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_with_quotations
+    skip
+    phrase = Phrase.new("Joe can't tell between 'large' and large.")
+    counts = {"joe"=>1, "can't"=>1, "tell"=>1, "between"=>1, "large"=>2, "and"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_multiple_spaces_not_detected_as_a_word
+    skip
+    phrase = Phrase.new(" multiple   whitespaces")
+    counts = {"multiple"=>1, "whitespaces"=>1}
+    assert_equal counts, phrase.word_count
+  end
+end

--- a/ruby/word-count/word_count_test.rb
+++ b/ruby/word-count/word_count_test.rb
@@ -25,42 +25,42 @@ class WordCountTest < Minitest::Test
   end
 
   def test_handles_cramped_lists
-    skip
+    # skip
     phrase = Phrase.new("one,two,three")
     counts = {"one"=>1, "two"=>1, "three"=>1}
     assert_equal counts, phrase.word_count
   end
 
   def test_handles_expanded_lists
-    skip
+    # skip
     phrase = Phrase.new("one,\ntwo,\nthree")
     counts = {"one"=>1, "two"=>1, "three"=>1}
     assert_equal counts, phrase.word_count
   end
 
   def test_ignore_punctuation
-    skip
+    # skip
     phrase = Phrase.new("car: carpet as java: javascript!!&@$%^&")
     counts = {"car"=>1, "carpet"=>1, "as"=>1, "java"=>1, "javascript"=>1}
     assert_equal counts, phrase.word_count
   end
 
   def test_include_numbers
-    skip
+    # skip
     phrase = Phrase.new("testing, 1, 2 testing")
     counts = {"testing"=>2, "1"=>1, "2"=>1}
     assert_equal counts, phrase.word_count
   end
 
   def test_normalize_case
-    skip
+    # skip
     phrase = Phrase.new("go Go GO Stop stop")
     counts = {"go"=>3, "stop"=>2}
     assert_equal counts, phrase.word_count
   end
 
   def test_with_apostrophes
-    skip
+    # skip
     phrase = Phrase.new("First: don't laugh. Then: don't cry.")
     counts = {"first"=>1, "don't"=>2, "laugh"=>1, "then"=>1, "cry"=>1}
     assert_equal counts, phrase.word_count
@@ -74,7 +74,7 @@ class WordCountTest < Minitest::Test
   end
 
   def test_multiple_spaces_not_detected_as_a_word
-    skip
+    # skip
     phrase = Phrase.new(" multiple   whitespaces")
     counts = {"multiple"=>1, "whitespaces"=>1}
     assert_equal counts, phrase.word_count


### PR DESCRIPTION
W.I.P.
Test for quotation marks does not pass. I believe that regex look-ahead and behind might be the solution in order to detect the quotation mark, and ignore the apostrophe.

Given a phrase, count the occurrences of each word in that phrase.

For example for the input "olly olly in come free"

olly: 2
in: 1
come: 1
free: 1