### PR TITLE
Raindrops

### DIFF
--- a/ruby/raindrops/.exercism/metadata.json
+++ b/ruby/raindrops/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"ruby","exercise":"raindrops","id":"84057bad470349bf845469ee1f4121da","url":"https://exercism.io/my/solutions/84057bad470349bf845469ee1f4121da","handle":"n-flint","is_requester":true,"auto_approve":false}

--- a/ruby/raindrops/README.md
+++ b/ruby/raindrops/README.md
@@ -1,0 +1,48 @@
+# Raindrops
+
+Convert a number to a string, the contents of which depend on the number's factors.
+
+- If the number has 3 as a factor, output 'Pling'.
+- If the number has 5 as a factor, output 'Plang'.
+- If the number has 7 as a factor, output 'Plong'.
+- If the number does not have 3, 5, or 7 as a factor,
+  just pass the number's digits straight through.
+
+## Examples
+
+- 28's factors are 1, 2, 4, **7**, 14, 28.
+  - In raindrop-speak, this would be a simple "Plong".
+- 30's factors are 1, 2, **3**, **5**, 6, 10, 15, 30.
+  - In raindrop-speak, this would be a "PlingPlang".
+- 34 has four factors: 1, 2, 17, and 34.
+  - In raindrop-speak, this would be "34".
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby raindrops_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride raindrops_test.rb
+
+
+## Source
+
+A variation on a famous interview question intended to weed out potential candidates. [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/ruby/raindrops/raindrops.rb
+++ b/ruby/raindrops/raindrops.rb
@@ -1,0 +1,32 @@
+require 'prime'
+
+class Raindrops
+
+  def self.convert(int_input)
+    factor_array = find_factors(int_input)
+    output = find_text(factor_array)
+    if output == ''
+      return int_input.to_s
+    else
+      output
+    end
+  end
+
+  def self.find_factors(int_input)
+    factors = []
+      (1..int_input).select do |int|
+        factors << int if int_input % int == 0
+      end
+    factors
+  end
+
+  def self.find_text(factors_input)
+    output = ''
+    factors_input.each do |f|
+        output.insert(-1, 'Pling') if f == 3
+        output.insert(-1, 'Plang') if f == 5
+        output.insert(-1, 'Plong') if f == 7
+    end
+    output
+  end
+end

--- a/ruby/raindrops/raindrops_test.rb
+++ b/ruby/raindrops/raindrops_test.rb
@@ -1,0 +1,95 @@
+require 'minitest/autorun'
+require_relative 'raindrops'
+
+# Common test data version: 1.1.0 99de15d
+class RaindropsTest < Minitest::Test
+  def test_the_sound_for_1_is_1
+    # skip
+    assert_equal "1", Raindrops.convert(1)
+  end
+
+  def test_the_sound_for_3_is_pling
+    # skip
+    assert_equal "Pling", Raindrops.convert(3)
+  end
+
+  def test_the_sound_for_5_is_plang
+    # skip
+    assert_equal "Plang", Raindrops.convert(5)
+  end
+
+  def test_the_sound_for_7_is_plong
+    # skip
+    assert_equal "Plong", Raindrops.convert(7)
+  end
+
+  def test_the_sound_for_6_is_pling_as_it_has_a_factor_3
+    # skip
+    assert_equal "Pling", Raindrops.convert(6)
+  end
+
+  def test_2_to_the_power_3_does_not_make_a_raindrop_sound_as_3_is_the_exponent_not_the_base
+    # skip
+    assert_equal "8", Raindrops.convert(8)
+  end
+
+  def test_the_sound_for_9_is_pling_as_it_has_a_factor_3
+    # skip
+    assert_equal "Pling", Raindrops.convert(9)
+  end
+
+  def test_the_sound_for_10_is_plang_as_it_has_a_factor_5
+    # skip
+    assert_equal "Plang", Raindrops.convert(10)
+  end
+
+  def test_the_sound_for_14_is_plong_as_it_has_a_factor_of_7
+    # skip
+    assert_equal "Plong", Raindrops.convert(14)
+  end
+
+  def test_the_sound_for_15_is_plingplang_as_it_has_factors_3_and_5
+    # skip
+    assert_equal "PlingPlang", Raindrops.convert(15)
+  end
+
+  def test_the_sound_for_21_is_plingplong_as_it_has_factors_3_and_7
+    # skip
+    assert_equal "PlingPlong", Raindrops.convert(21)
+  end
+
+  def test_the_sound_for_25_is_plang_as_it_has_a_factor_5
+    # skip
+    assert_equal "Plang", Raindrops.convert(25)
+  end
+
+  def test_the_sound_for_27_is_pling_as_it_has_a_factor_3
+    # skip
+    assert_equal "Pling", Raindrops.convert(27)
+  end
+
+  def test_the_sound_for_35_is_plangplong_as_it_has_factors_5_and_7
+    # skip
+    assert_equal "PlangPlong", Raindrops.convert(35)
+  end
+
+  def test_the_sound_for_49_is_plong_as_it_has_a_factor_7
+    # skip
+    assert_equal "Plong", Raindrops.convert(49)
+  end
+
+  def test_the_sound_for_52_is_52
+    # skip
+    assert_equal "52", Raindrops.convert(52)
+  end
+
+  def test_the_sound_for_105_is_plingplangplong_as_it_has_factors_3_5_and_7
+    # skip
+    assert_equal "PlingPlangPlong", Raindrops.convert(105)
+  end
+
+  def test_the_sound_for_3125_is_plang_as_it_has_a_factor_5
+    # skip
+    assert_equal "Plang", Raindrops.convert(3125)
+  end
+end


### PR DESCRIPTION
Convert a number to a string, the contents of which depend on the number's factors.

If the number has 3 as a factor, output 'Pling'.
If the number has 5 as a factor, output 'Plang'.
If the number has 7 as a factor, output 'Plong'.
If the number does not have 3, 5, or 7 as a factor, just pass the number's digits straight through.
Examples
28's factors are 1, 2, 4, 7, 14, 28.
In raindrop-speak, this would be a simple "Plong".
30's factors are 1, 2, 3, 5, 6, 10, 15, 30.
In raindrop-speak, this would be a "PlingPlang".
34 has four factors: 1, 2, 17, and 34.
In raindrop-speak, this would be "34".