### PR TITLE
Hamming

### DIFF
--- a/ruby/hamming/.exercism/metadata.json
+++ b/ruby/hamming/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"ruby","exercise":"hamming","id":"8badd52cba894d22b99b2db01a73ef6e","url":"https://exercism.io/my/solutions/8badd52cba894d22b99b2db01a73ef6e","handle":"n-flint","is_requester":true,"auto_approve":false}

--- a/ruby/hamming/README.md
+++ b/ruby/hamming/README.md
@@ -1,0 +1,67 @@
+# Hamming
+
+Calculate the Hamming difference between two DNA strands.
+
+A mutation is simply a mistake that occurs during the creation or
+copying of a nucleic acid, in particular DNA. Because nucleic acids are
+vital to cellular functions, mutations tend to cause a ripple effect
+throughout the cell. Although mutations are technically mistakes, a very
+rare mutation may equip the cell with a beneficial attribute. In fact,
+the macro effects of evolution are attributable by the accumulated
+result of beneficial microscopic mutations over many generations.
+
+The simplest and most common type of nucleic acid mutation is a point
+mutation, which replaces one base with another at a single nucleotide.
+
+By counting the number of differences between two homologous DNA strands
+taken from different genomes with a common ancestor, we get a measure of
+the minimum number of point mutations that could have occurred on the
+evolutionary path between the two strands.
+
+This is called the 'Hamming distance'.
+
+It is found by comparing two DNA strands and counting how many of the
+nucleotides are different from their equivalent in the other string.
+
+    GAGCCTACTAACGGGAT
+    CATCGTAATGACGGCCT
+    ^ ^ ^  ^ ^    ^^
+
+The Hamming distance between these two DNA strands is 7.
+
+# Implementation notes
+
+The Hamming distance is only defined for sequences of equal length, so
+an attempt to calculate it between sequences of different lengths should
+not work. The general handling of this situation (e.g., raising an
+exception vs returning a special value) may differ between languages.
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby hamming_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride hamming_test.rb
+
+
+## Source
+
+The Calculating Point Mutations problem at Rosalind [http://rosalind.info/problems/hamm/](http://rosalind.info/problems/hamm/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/ruby/hamming/RUNNING_TESTS.md
+++ b/ruby/hamming/RUNNING_TESTS.md
@@ -1,0 +1,56 @@
+# Running Tests
+
+In order to complete this exercise, and all of the subsequent exercises, you
+will need to pass multiple tests.
+
+## Understanding Test Results
+
+After you have created and saved `hamming.rb`, run the test suite. You should
+see output like the following:
+
+    # Running:
+
+    SSSSSSESSSSSSSSS
+
+    Finished in 0.002593s, 6170.4588 runs/s, 0.0000 assertions/s.
+
+      1) Error:
+    HammingTest#test_identical_strands:
+    NameError: uninitialized constant HammingTest::Hamming
+    Did you mean?  HammingTest
+        ../hamming/hamming_test.rb:9:in `test_identical_strands'
+
+    16 runs, 0 assertions, 0 failures, 1 errors, 15 skips
+
+    You have skipped tests. Run with --verbose for details.
+
+
+The letters `SSSSSSESSSSSSSSS` show that there are sixteen tests altogether,
+that one of them has an error (`E`), and that the rest of them are skipped (all
+the `S` letters).
+
+The tests are run in randomized order, which will cause the letters to display
+in random order as well.
+
+The goal is to have all passing tests, which will show in two places:
+
+1. `SSSSSSESSSSSSSSS` will become a series dots: `................`, 
+
+2. The line at the bottom will read `16 runs, 16 assertions, 0 failures, 0
+   errors, 0 skips`.
+
+## Passing Tests
+
+Write enough code to change the Error to Failure, and finally to Passing.
+
+Open `hamming_test.rb`, and find the word "skip". All but the first test start
+with "skip", which tells Minitest to ignore the test. This is so that you don't
+have to deal with all the failures at once.
+
+To activate the next test, delete the "skip", or comment it out, and run the
+test suite again.
+
+## Wash, Rinse, Repeat
+
+Delete one "skip" at a time, and make each test pass before you move to the
+next one.

--- a/ruby/hamming/hamming.rb
+++ b/ruby/hamming/hamming.rb
@@ -1,0 +1,29 @@
+class Hamming
+
+  def self.compute(strand_1, strand_2)
+    if strand_1 == '' || strand_2 == ''
+      return 0
+    elsif
+      strand_1.length != strand_2.length
+      raise ArgumentError
+    else
+      matched_strands(strand_1, strand_2)
+    end
+  end
+
+  def self.matched_strands(strand_1, strand_2)
+    s1 = []
+    s2 = []
+    strand_1.each_char do |c|
+      s1 << c
+    end
+    strand_2.each_char do |c|
+      s2 << c
+    end
+    counter = 0
+    s1.each_with_index do |x, i|
+      counter += 1 if x != s2[i]
+    end
+    counter
+  end
+end

--- a/ruby/hamming/hamming_test.rb
+++ b/ruby/hamming/hamming_test.rb
@@ -1,0 +1,44 @@
+require 'minitest/autorun'
+require_relative 'hamming'
+
+# Common test data version: 2.2.0 4c453c8
+class HammingTest < Minitest::Test
+  def test_empty_strands
+    # skip
+    assert_equal 0, Hamming.compute('', '')
+  end
+
+  def test_single_letter_identical_strands
+    # skip
+    assert_equal 0, Hamming.compute('A', 'A')
+  end
+
+  def test_single_letter_different_strands
+    # skip
+    assert_equal 1, Hamming.compute('G', 'T')
+  end
+
+  def test_long_identical_strands
+    # skip
+    assert_equal 0, Hamming.compute('GGACTGAAATCTG', 'GGACTGAAATCTG')
+  end
+
+  def test_long_different_strands
+    # skip
+    assert_equal 9, Hamming.compute('GGACGGATTCTG', 'AGGACGGATTCT')
+  end
+
+  def test_disallow_first_strand_longer
+    # skip
+    assert_raises(ArgumentError) do
+      Hamming.compute('AATG', 'AAA')
+    end
+  end
+
+  def test_disallow_second_strand_longer
+    # skip
+    assert_raises(ArgumentError) do
+      Hamming.compute('ATA', 'AGTG')
+    end
+  end
+end


### PR DESCRIPTION
Calculate the Hamming difference between two DNA strands.

A mutation is simply a mistake that occurs during the creation or copying of a nucleic acid, in particular DNA. Because nucleic acids are vital to cellular functions, mutations tend to cause a ripple effect throughout the cell. Although mutations are technically mistakes, a very rare mutation may equip the cell with a beneficial attribute. In fact, the macro effects of evolution are attributable by the accumulated result of beneficial microscopic mutations over many generations.

The simplest and most common type of nucleic acid mutation is a point mutation, which replaces one base with another at a single nucleotide.

By counting the number of differences between two homologous DNA strands taken from different genomes with a common ancestor, we get a measure of the minimum number of point mutations that could have occurred on the evolutionary path between the two strands.

This is called the 'Hamming distance'.

It is found by comparing two DNA strands and counting how many of the nucleotides are different from their equivalent in the other string.

GAGCCTACTAACGGGAT
CATCGTAATGACGGCCT
^ ^ ^  ^ ^    ^^
The Hamming distance between these two DNA strands is 7.

Implementation notes
The Hamming distance is only defined for sequences of equal length, so an attempt to calculate it between sequences of different lengths should not work. The general handling of this situation (e.g., raising an exception vs returning a special value) may differ between languages.