### PR TITLE
Robot Name WIP

### DIFF
--- a/ruby/robot-name/.exercism/metadata.json
+++ b/ruby/robot-name/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"ruby","exercise":"robot-name","id":"3cf2ab5e26404cc8919dec6e496e29ec","url":"https://exercism.io/my/solutions/3cf2ab5e26404cc8919dec6e496e29ec","handle":"n-flint","is_requester":true,"auto_approve":false}

--- a/ruby/robot-name/README.md
+++ b/ruby/robot-name/README.md
@@ -1,0 +1,55 @@
+# Robot Name
+
+Manage robot factory settings.
+
+When robots come off the factory floor, they have no name.
+
+The first time you boot them up, a random name is generated in the format
+of two uppercase letters followed by three digits, such as RX837 or BC811.
+
+Every once in a while we need to reset a robot to its factory settings,
+which means that their name gets wiped. The next time you ask, it will
+respond with a new random name.
+
+The names must be random: they should not follow a predictable sequence.
+Random names means a risk of collisions. Your solution must ensure that
+every existing robot has a unique name.
+
+
+In order to make this easier to test, your solution will need to implement a
+`Robot.forget` method that clears any shared state that might exist to track
+duplicate robot names.
+
+Bonus points if this method does not need to do anything for your solution.
+
+
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby robot_name_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride robot_name_test.rb
+
+
+## Source
+
+A debugging session with Paul Blackwell at gSchool. [http://gschool.it](http://gschool.it)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/ruby/robot-name/robot_name.rb
+++ b/ruby/robot-name/robot_name.rb
@@ -1,0 +1,32 @@
+class Robot
+  attr_reader :name
+
+  def self.forget
+    # Magic to delete all the robots names? Needed for the test
+  end
+
+  def initialize
+    @name = random_name
+  end
+
+  def current_robots
+    []
+  end
+
+  def random_name
+    name = []
+    name << ('A'..'Z').to_a.sample(2).flatten
+    name << (1..9).to_a.sample(3).map {|d| d.to_s}
+    if current_robots.include?(name.join)
+      random_name
+    else
+      current_robots << name.join
+    end
+    name.join
+  end
+
+  def reset
+    current_robots.delete(@name)
+    @name = random_name
+  end
+end

--- a/ruby/robot-name/robot_name_test.rb
+++ b/ruby/robot-name/robot_name_test.rb
@@ -1,0 +1,90 @@
+require 'minitest/autorun'
+require_relative 'robot_name'
+
+class RobotTest < Minitest::Test
+  NAME_REGEXP = /^[A-Z]{2}\d{3}$/
+
+  def setup
+    Robot.forget
+  end
+
+  def test_can_create_a_robot
+    # skip
+    refute_nil Robot.new
+  end
+
+  def test_has_name
+    # skip
+    assert_match NAME_REGEXP, Robot.new.name
+  end
+
+  def test_name_sticks
+    # skip
+    robot = Robot.new
+    original_name = robot.name
+    assert_equal original_name, robot.name
+  end
+
+  def test_reset_changes_name
+    # skip
+    robot = Robot.new
+    original_name = robot.name
+    robot.reset
+    refute_equal original_name, robot.name
+  end
+
+  def test_reset_before_name_called_does_not_cause_an_error
+    # skip
+    robot = Robot.new
+    robot.reset
+    assert_match NAME_REGEXP, Robot.new.name
+  end
+
+  def test_reset_multiple_times
+    # skip
+    robot = Robot.new
+    names = []
+    5.times do
+      robot.reset
+      names << robot.name
+    end
+    # This will probably be 5, but name uniqueness is only a requirement
+    # accross multiple robots and consecutive calls to reset.
+    assert names.uniq.size > 1
+  end
+
+  def test_different_robots_have_different_names
+    # skip
+    refute_equal Robot.new.name, Robot.new.name
+  end
+
+  # This test assumes you're using Kernel.rand as a source of randomness
+  def test_different_name_when_chosen_name_is_taken
+    skip
+    same_seed = 1234
+    Kernel.srand same_seed
+    robot_1 = Robot.new
+    name_1  = robot_1.name
+    Kernel.srand same_seed
+    robot_2 = Robot.new
+    name_2 = robot_2.name
+    refute_equal name_1, name_2
+  end
+
+  def test_generate_all_robots
+    skip
+    all_names_count = 26 * 26 * 1000
+    time_limit = Time.now + 60 # seconds
+    seen_names = Hash.new(0)
+    robots = []
+    while seen_names.size < all_names_count && Time.now < time_limit
+      robot = Robot.new
+      seen_names[robot.name] += 1
+      robots << robot
+    end
+    timeout_message = "Timed out trying to generate all possible robots"
+    assert_equal all_names_count, robots.size, timeout_message
+    assert seen_names.values.all? { |count| count == 1 }, "Some names used more than once"
+    assert seen_names.keys.all? { |name| name.match(NAME_REGEXP) }, "Not all names match #{NAME_REGEXP}"
+  end
+end


### PR DESCRIPTION
Work In Progress
Last two tests are not passing. The first ensures that a new name is actually chosen if it is detected as being not random. The last test generates all robots? I do not support a robot uprising. I will not partake. 

Manage robot factory settings.

When robots come off the factory floor, they have no name.

The first time you boot them up, a random name is generated in the format of two uppercase letters followed by three digits, such as RX837 or BC811.

Every once in a while we need to reset a robot to its factory settings, which means that their name gets wiped. The next time you ask, it will respond with a new random name.

The names must be random: they should not follow a predictable sequence. Random names means a risk of collisions. Your solution must ensure that every existing robot has a unique name.

In order to make this easier to test, your solution will need to implement a Robot.forget method that clears any shared state that might exist to track duplicate robot names.

Bonus points if this method does not need to do anything for your solution.