### PR TITLE
Leap

### DIFF
--- a/ruby/leap/.exercism/metadata.json
+++ b/ruby/leap/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"ruby","exercise":"leap","id":"863cd05ea426441581df81906ab41737","url":"https://exercism.io/my/solutions/863cd05ea426441581df81906ab41737","handle":"n-flint","is_requester":true,"auto_approve":false}

--- a/ruby/leap/README.md
+++ b/ruby/leap/README.md
@@ -1,0 +1,57 @@
+# Leap
+
+Given a year, report if it is a leap year.
+
+The tricky thing here is that a leap year in the Gregorian calendar occurs:
+
+```text
+on every year that is evenly divisible by 4
+  except every year that is evenly divisible by 100
+    unless the year is also evenly divisible by 400
+```
+
+For example, 1997 is not a leap year, but 1996 is.  1900 is not a leap
+year, but 2000 is.
+
+If your language provides a method in the standard library that does
+this look-up, pretend it doesn't exist and implement it yourself.
+
+## Notes
+
+Though our exercise adopts some very simple rules, there is more to
+learn!
+
+For a delightful, four minute explanation of the whole leap year
+phenomenon, go watch [this youtube video][video].
+
+[video]: http://www.youtube.com/watch?v=xX96xng7sAE
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby leap_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride leap_test.rb
+
+
+## Source
+
+JavaRanch Cattle Drive, exercise 3 [http://www.javaranch.com/leap.jsp](http://www.javaranch.com/leap.jsp)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/ruby/leap/leap.rb
+++ b/ruby/leap/leap.rb
@@ -1,0 +1,14 @@
+class Year
+
+  def self.leap?(input_date)
+    if input_date % 4 == 0
+      if input_date % 100 == 0
+        true if input_date % 400 == 0
+      else
+        true
+      end
+    else
+      false
+    end
+  end
+end

--- a/ruby/leap/leap_test.rb
+++ b/ruby/leap/leap_test.rb
@@ -1,0 +1,39 @@
+require 'minitest/autorun'
+require_relative 'leap'
+
+# Common test data version: 1.4.0 3134d31
+class Date
+  def leap?
+    raise RuntimeError, "Implement this yourself instead of using Ruby's implementation."
+  end
+
+  alias gregorian_leap? leap?
+  alias julian_leap? leap?
+end
+
+class YearTest < Minitest::Test
+  def test_year_not_divisible_by_4_common_year
+    # skip
+    refute Year.leap?(2015), "Expected 'false', 2015 is not a leap year."
+  end
+
+  def test_year_divisible_by_4_not_divisible_by_100_leap_year
+    # skip
+    assert Year.leap?(1996), "Expected 'true', 1996 is a leap year."
+  end
+
+  def test_year_divisible_by_100_not_divisible_by_400_common_year
+    # skip
+    refute Year.leap?(2100), "Expected 'false', 2100 is not a leap year."
+  end
+
+  def test_year_divisible_by_400_leap_year
+    # skip
+    assert Year.leap?(2000), "Expected 'true', 2000 is a leap year."
+  end
+
+  def test_year_divisible_by_200_not_divisible_by_400_common_year
+    # skip
+    refute Year.leap?(1800), "Expected 'false', 1800 is not a leap year."
+  end
+end


### PR DESCRIPTION
Given a year, report if it is a leap year.

The tricky thing here is that a leap year in the Gregorian calendar occurs:

on every year that is evenly divisible by 4
  except every year that is evenly divisible by 100
    unless the year is also evenly divisible by 400
For example, 1997 is not a leap year, but 1996 is. 1900 is not a leap year, but 2000 is.

If your language provides a method in the standard library that does this look-up, pretend it doesn't exist and implement it yourself.