### PR TITLE
Phone Number

### DIFF
--- a/ruby/phone-number/.exercism/metadata.json
+++ b/ruby/phone-number/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"ruby","exercise":"phone-number","id":"efae8b361886455aa41471273f920d9b","url":"https://exercism.io/my/solutions/efae8b361886455aa41471273f920d9b","handle":"n-flint","is_requester":true,"auto_approve":false}

--- a/ruby/phone-number/README.md
+++ b/ruby/phone-number/README.md
@@ -1,0 +1,59 @@
+# Phone Number
+
+Clean up user-entered phone numbers so that they can be sent SMS messages.
+
+The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda. All NANP-countries share the same international country code: `1`.
+
+NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as *area code*, followed by a seven-digit local number. The first three digits of the local number represent the *exchange code*, followed by the unique four-digit number which is the *subscriber number*.
+
+The format is usually represented as
+
+```text
+(NXX)-NXX-XXXX
+```
+
+where `N` is any digit from 2 through 9 and `X` is any digit from 0 through 9.
+
+Your task is to clean up differently formatted telephone numbers by removing punctuation and the country code (1) if present.
+
+For example, the inputs
+- `+1 (613)-995-0253`
+- `613-995-0253`
+- `1 613 995 0253`
+- `613.995.0253`
+
+should all produce the output
+
+`6139950253`
+
+**Note:** As this exercise only deals with telephone numbers used in NANP-countries, only 1 is considered a valid country code.
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby phone_number_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride phone_number_test.rb
+
+
+## Source
+
+Event Manager by JumpstartLab [http://tutorials.jumpstartlab.com/projects/eventmanager.html](http://tutorials.jumpstartlab.com/projects/eventmanager.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/ruby/phone-number/phone_number.rb
+++ b/ruby/phone-number/phone_number.rb
@@ -1,0 +1,40 @@
+class PhoneNumber
+
+  def self.clean(phone_input)
+    num_arr = just_nums(phone_input)
+    nine_num = validate_length(num_arr)
+    check_codes(nine_num) unless nine_num == nil
+  end
+
+  def self.just_nums(phone_input)
+    num_arr = []
+    phone_input.each_char do |c|
+      num_arr << c if ('0'..'9').include?(c)
+    end
+    num_arr.join
+  end
+
+  def self.validate_length(num_input)
+    if num_input.length < 10
+      nil
+    elsif num_input.length == 11 && num_input[0] == '1'
+      return num_input[1..-1] #removes first index, '1'
+    elsif num_input.length == 11 && num_input[0] != '1'
+      nil
+    elsif num_input.length > 10
+      nil
+    else
+      num_input
+    end
+  end
+
+  def self.check_codes(input)
+    if input[0] == '0' || input[0] == '1'
+      return nil
+    elsif input[3] == '0' || input[3] == '1'
+      return nil
+    else
+      input
+    end
+  end
+end

--- a/ruby/phone-number/phone_number_test.rb
+++ b/ruby/phone-number/phone_number_test.rb
@@ -1,0 +1,95 @@
+require 'minitest/autorun'
+require_relative 'phone_number'
+
+# Common test data version: 1.6.1 fc57696
+class PhoneNumberTest < Minitest::Test
+  def test_cleans_the_number
+    # skip
+    assert_equal "2234567890", PhoneNumber.clean("(223) 456-7890")
+  end
+
+  def test_cleans_numbers_with_dots
+    # skip
+    assert_equal "2234567890", PhoneNumber.clean("223.456.7890")
+  end
+
+  def test_cleans_numbers_with_multiple_spaces
+    # skip
+    assert_equal "2234567890", PhoneNumber.clean("223 456   7890   ")
+  end
+
+  def test_invalid_when_9_digits
+    # skip
+    assert_nil PhoneNumber.clean("123456789")
+  end
+
+  def test_invalid_when_11_digits_does_not_start_with_a_1
+    # skip
+    assert_nil PhoneNumber.clean("22234567890")
+  end
+
+  def test_valid_when_11_digits_and_starting_with_1
+    # skip
+    assert_equal "2234567890", PhoneNumber.clean("12234567890")
+  end
+
+  def test_valid_when_11_digits_and_starting_with_1_even_with_punctuation
+    # skip
+    assert_equal "2234567890", PhoneNumber.clean("+1 (223) 456-7890")
+  end
+
+  def test_invalid_when_more_than_11_digits
+    # skip
+    assert_nil PhoneNumber.clean("321234567890")
+  end
+
+  def test_invalid_with_letters
+    # skip
+    assert_nil PhoneNumber.clean("123-abc-7890")
+  end
+
+  def test_invalid_with_punctuations
+    # skip
+    assert_nil PhoneNumber.clean("123-@:!-7890")
+  end
+
+  def test_invalid_if_area_code_starts_with_0
+    # skip
+    assert_nil PhoneNumber.clean("(023) 456-7890")
+  end
+
+  def test_invalid_if_area_code_starts_with_1
+    # skip
+    assert_nil PhoneNumber.clean("(123) 456-7890")
+  end
+
+  def test_invalid_if_exchange_code_starts_with_0
+    # skip
+    assert_nil PhoneNumber.clean("(223) 056-7890")
+  end
+
+  def test_invalid_if_exchange_code_starts_with_1
+    # skip
+    assert_nil PhoneNumber.clean("(223) 156-7890")
+  end
+
+  def test_invalid_if_area_code_starts_with_0_on_valid_11_digit_number
+    # skip
+    assert_nil PhoneNumber.clean("1 (023) 456-7890")
+  end
+
+  def test_invalid_if_area_code_starts_with_1_on_valid_11_digit_number
+    # skip
+    assert_nil PhoneNumber.clean("1 (123) 456-7890")
+  end
+
+  def test_invalid_if_exchange_code_starts_with_0_on_valid_11_digit_number
+    # skip
+    assert_nil PhoneNumber.clean("1 (223) 056-7890")
+  end
+
+  def test_invalid_if_exchange_code_starts_with_1_on_valid_11_digit_number
+    # skip
+    assert_nil PhoneNumber.clean("1 (223) 156-7890")
+  end
+end


### PR DESCRIPTION
Clean up user-entered phone numbers so that they can be sent SMS messages.

The North American Numbering Plan (NANP) is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda. All NANP-countries share the same international country code: 1.

NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as area code, followed by a seven-digit local number. The first three digits of the local number represent the exchange code, followed by the unique four-digit number which is the subscriber number.

The format is usually represented as

(NXX)-NXX-XXXX
where N is any digit from 2 through 9 and X is any digit from 0 through 9.

Your task is to clean up differently formatted telephone numbers by removing punctuation and the country code (1) if present.

For example, the inputs

+1 (613)-995-0253
613-995-0253
1 613 995 0253
613.995.0253
should all produce the output

6139950253

Note: As this exercise only deals with telephone numbers used in NANP-countries, only 1 is considered a valid country code.