### PR TITLE
Atbash Cipher

### DIFF
--- a/ruby/atbash-cipher/.exercism/metadata.json
+++ b/ruby/atbash-cipher/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"ruby","exercise":"atbash-cipher","id":"fe87ce89a1864fa2a49541187632013d","url":"https://exercism.io/my/solutions/fe87ce89a1864fa2a49541187632013d","handle":"n-flint","is_requester":true,"auto_approve":false}

--- a/ruby/atbash-cipher/README.md
+++ b/ruby/atbash-cipher/README.md
@@ -1,0 +1,59 @@
+# Atbash Cipher
+
+Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.
+
+The Atbash cipher is a simple substitution cipher that relies on
+transposing all the letters in the alphabet such that the resulting
+alphabet is backwards. The first letter is replaced with the last
+letter, the second with the second-last, and so on.
+
+An Atbash cipher for the Latin alphabet would be as follows:
+
+```text
+Plain:  abcdefghijklmnopqrstuvwxyz
+Cipher: zyxwvutsrqponmlkjihgfedcba
+```
+
+It is a very weak cipher because it only has one possible key, and it is
+a simple monoalphabetic substitution cipher. However, this may not have
+been an issue in the cipher's time.
+
+Ciphertext is written out in groups of fixed length, the traditional group size
+being 5 letters, and punctuation is excluded. This is to make it harder to guess
+things based on word boundaries.
+
+## Examples
+
+- Encoding `test` gives `gvhg`
+- Decoding `gvhg` gives `test`
+- Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `thequickbrownfoxjumpsoverthelazydog`
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby atbash_cipher_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride atbash_cipher_test.rb
+
+
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/Atbash](http://en.wikipedia.org/wiki/Atbash)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/ruby/atbash-cipher/atbash_cipher.rb
+++ b/ruby/atbash-cipher/atbash_cipher.rb
@@ -1,0 +1,35 @@
+class Atbash
+
+  @reg_alph = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"]
+  @rev_alph = ["z", "y", "x", "w", "v", "u", "t", "s", "r", "q", "p", "o", "n", "m", "l", "k", "j", "i", "h", "g", "f", "e", "d", "c", "b", "a"]
+
+  def self.encode(input)
+    encoded = []
+    input.each_char do |c|
+      encoded << c if ('0'..'9').include?(c)
+      @reg_alph.each_with_index do |l, i|
+        encoded << @rev_alph[i] if l == c.downcase
+      end
+    end
+    split_five(encoded)
+  end
+
+  def self.decode(input)
+    decoded = []
+    input.each_char do |c|
+      decoded << c if ('0'..'9').include?(c)
+      @rev_alph.each_with_index do |l, i|
+        decoded << @reg_alph[i] if l == c.downcase
+      end
+    end
+    decoded.join
+  end
+
+  def self.split_five(input_array)
+    es = []
+    input_array.each_slice(5) do |slice|
+      es << slice.join
+    end
+    es.join(' ')
+  end
+end

--- a/ruby/atbash-cipher/atbash_cipher_test.rb
+++ b/ruby/atbash-cipher/atbash_cipher_test.rb
@@ -1,0 +1,103 @@
+require 'minitest/autorun'
+require_relative 'atbash_cipher'
+
+# Common test data version: 1.2.0 d5238bd
+class AtbashCipherTest < Minitest::Test
+  def test_encode_yes
+    # skip
+    plaintext = 'yes'
+    ciphertext = 'bvh'
+    assert_equal ciphertext, Atbash.encode(plaintext)
+  end
+
+  def test_encode_no
+    # skip
+    plaintext = 'no'
+    ciphertext = 'ml'
+    assert_equal ciphertext, Atbash.encode(plaintext)
+  end
+
+  def test_encode_omg
+    # skip
+    plaintext = 'OMG'
+    ciphertext = 'lnt'
+    assert_equal ciphertext, Atbash.encode(plaintext)
+  end
+
+  def test_encode_spaces
+    # skip
+    plaintext = 'O M G'
+    ciphertext = 'lnt'
+    assert_equal ciphertext, Atbash.encode(plaintext)
+  end
+
+  def test_encode_mindblowingly
+    # skip
+    plaintext = 'mindblowingly'
+    ciphertext = 'nrmwy oldrm tob'
+    assert_equal ciphertext, Atbash.encode(plaintext)
+  end
+
+  def test_encode_numbers
+    # skip
+    plaintext = 'Testing,1 2 3, testing.'
+    ciphertext = 'gvhgr mt123 gvhgr mt'
+    assert_equal ciphertext, Atbash.encode(plaintext)
+  end
+
+  def test_encode_deep_thought
+    # skip
+    plaintext = 'Truth is fiction.'
+    ciphertext = 'gifgs rhurx grlm'
+    assert_equal ciphertext, Atbash.encode(plaintext)
+  end
+
+  def test_encode_all_the_letters
+    # skip
+    plaintext = 'The quick brown fox jumps over the lazy dog.'
+    ciphertext = 'gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt'
+    assert_equal ciphertext, Atbash.encode(plaintext)
+  end
+
+  def test_decode_exercism
+    # skip
+    ciphertext = 'vcvix rhn'
+    plaintext = 'exercism'
+    assert_equal plaintext, Atbash.decode(ciphertext)
+  end
+
+  def test_decode_a_sentence
+    # skip
+    ciphertext = 'zmlyh gzxov rhlug vmzhg vkkrm thglm v'
+    plaintext = 'anobstacleisoftenasteppingstone'
+    assert_equal plaintext, Atbash.decode(ciphertext)
+  end
+
+  def test_decode_numbers
+    # skip
+    ciphertext = 'gvhgr mt123 gvhgr mt'
+    plaintext = 'testing123testing'
+    assert_equal plaintext, Atbash.decode(ciphertext)
+  end
+
+  def test_decode_all_the_letters
+    # skip
+    ciphertext = 'gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt'
+    plaintext = 'thequickbrownfoxjumpsoverthelazydog'
+    assert_equal plaintext, Atbash.decode(ciphertext)
+  end
+
+  def test_decode_with_too_many_spaces
+    # skip
+    ciphertext = 'vc vix    r hn'
+    plaintext = 'exercism'
+    assert_equal plaintext, Atbash.decode(ciphertext)
+  end
+
+  def test_decode_with_no_spaces
+    # skip
+    ciphertext = 'zmlyhgzxovrhlugvmzhgvkkrmthglmv'
+    plaintext = 'anobstacleisoftenasteppingstone'
+    assert_equal plaintext, Atbash.decode(ciphertext)
+  end
+end


### PR DESCRIPTION
Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.

The Atbash cipher is a simple substitution cipher that relies on transposing all the letters in the alphabet such that the resulting alphabet is backwards. The first letter is replaced with the last letter, the second with the second-last, and so on.

An Atbash cipher for the Latin alphabet would be as follows:

Plain:  abcdefghijklmnopqrstuvwxyz
Cipher: zyxwvutsrqponmlkjihgfedcba
It is a very weak cipher because it only has one possible key, and it is a simple monoalphabetic substitution cipher. However, this may not have been an issue in the cipher's time.

Ciphertext is written out in groups of fixed length, the traditional group size being 5 letters, and punctuation is excluded. This is to make it harder to guess things based on word boundaries.

Examples
Encoding test gives gvhg
Decoding gvhg gives test
Decoding gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt gives thequickbrownfoxjumpsoverthelazydog