### PR TITLE
Protein Translation

### DIFF
--- a/ruby/protein-translation/.exercism/metadata.json
+++ b/ruby/protein-translation/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"ruby","exercise":"protein-translation","id":"3092883bb2564497ac74fd5adf5435c3","url":"https://exercism.io/my/solutions/3092883bb2564497ac74fd5adf5435c3","handle":"n-flint","is_requester":true,"auto_approve":false}

--- a/ruby/protein-translation/README.md
+++ b/ruby/protein-translation/README.md
@@ -1,0 +1,72 @@
+# Protein Translation
+
+Translate RNA sequences into proteins.
+
+RNA can be broken into three nucleotide sequences called codons, and then translated to a polypeptide like so:
+
+RNA: `"AUGUUUUCU"` => translates to
+
+Codons: `"AUG", "UUU", "UCU"`
+=> which become a polypeptide with the following sequence =>
+
+Protein: `"Methionine", "Phenylalanine", "Serine"`
+
+There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise.  If it works for one codon, the program should work for all of them.
+However, feel free to expand the list in the test suite to include them all.
+
+There are also three terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.
+
+All subsequent codons after are ignored, like this:
+
+RNA: `"AUGUUUUCUUAAAUG"` =>
+
+Codons: `"AUG", "UUU", "UCU", "UAA", "AUG"` =>
+
+Protein: `"Methionine", "Phenylalanine", "Serine"`
+
+Note the stop codon `"UAA"` terminates the translation and the final methionine is not translated into the protein sequence.
+
+Below are the codons and resulting Amino Acids needed for the exercise.
+
+Codon                 | Protein
+:---                  | :---
+AUG                   | Methionine
+UUU, UUC              | Phenylalanine
+UUA, UUG              | Leucine
+UCU, UCC, UCA, UCG    | Serine
+UAU, UAC              | Tyrosine
+UGU, UGC              | Cysteine
+UGG                   | Tryptophan
+UAA, UAG, UGA         | STOP
+
+Learn more about [protein translation on Wikipedia](http://en.wikipedia.org/wiki/Translation_(biology))
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby protein_translation_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride protein_translation_test.rb
+
+
+## Source
+
+Tyler Long
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/ruby/protein-translation/protein_translation.rb
+++ b/ruby/protein-translation/protein_translation.rb
@@ -1,0 +1,45 @@
+class Translation
+
+  def self.of_codon(input)
+    if check_codon(input) == nil
+      raise InvalidCodonError
+    else
+    da_hash = {
+      'Methionine' =>	['AUG'],
+      'Phenylalanine': ['UUU', 'UUC'],
+      'Leucine': ['UUA', 'UUG'],
+      'Serine': ['UCU', 'UCC', 'UCA', 'UCG'],
+      'Tyrosine': ['UAU', 'UAC'],
+      'Cysteine': ['UGU', 'UGC'],
+      'Tryptophan': ['UGG'],
+      'STOP': ['UAA', 'UAG', 'UGA']
+    }
+    ops = []
+    da_hash.keys.each do |k|
+      ops << k if da_hash[k].include?(input)
+    end
+    ops.join
+  end
+  end
+
+  def self.of_rna(input)
+    proteins = []
+    tres = input.scan /.{1,3}/ #returns array of sets of 3
+    tres.each do |tre|
+      if of_codon(tre) != 'STOP'
+        proteins << of_codon(tre)
+      else
+        break
+      end
+    end
+    proteins
+  end
+
+  def self.check_codon(input)
+    if input.include?('U')
+      input
+    else
+      raise InvalidCodonError
+    end
+  end
+end

--- a/ruby/protein-translation/protein_translation_test.rb
+++ b/ruby/protein-translation/protein_translation_test.rb
@@ -1,0 +1,83 @@
+require 'minitest/autorun'
+require_relative 'protein_translation'
+
+class TranslationTest < Minitest::Test
+  def test_AUG_translates_to_methionine
+    assert_equal 'Methionine', Translation.of_codon('AUG')
+  end
+
+  def test_identifies_Phenylalanine_codons
+    # skip
+    assert_equal 'Phenylalanine', Translation.of_codon('UUU')
+    assert_equal 'Phenylalanine', Translation.of_codon('UUC')
+  end
+
+  def test_identifies_Leucine_codons
+    # skip
+    %w(UUA UUG).each do |codon|
+      assert_equal 'Leucine', Translation.of_codon(codon)
+    end
+  end
+
+  def test_identifies_Serine_codons
+    # skip
+    %w(UCU UCC UCA UCG).each do |codon|
+      assert_equal 'Serine', Translation.of_codon(codon)
+    end
+  end
+
+  def test_identifies_Tyrosine_codons
+    # skip
+    %w(UAU UAC).each do |codon|
+      assert_equal 'Tyrosine', Translation.of_codon(codon)
+    end
+  end
+
+  def test_identifies_Cysteine_codons
+    # skip
+    %w(UGU UGC).each do |codon|
+      assert_equal 'Cysteine', Translation.of_codon(codon)
+    end
+  end
+
+  def test_identifies_Tryptophan_codons
+    # skip
+    assert_equal 'Tryptophan', Translation.of_codon('UGG')
+  end
+
+  def test_identifies_stop_codons
+    # skip
+    %w(UAA UAG UGA).each do |codon|
+      assert_equal 'STOP', Translation.of_codon(codon)
+    end
+  end
+
+  def test_translates_rna_strand_into_correct_protein
+    # skip
+    strand = 'AUGUUUUGG'
+    expected = %w(Methionine Phenylalanine Tryptophan)
+    assert_equal expected, Translation.of_rna(strand)
+  end
+
+  def test_stops_translation_if_stop_codon_present
+    # skip
+    strand = 'AUGUUUUAA'
+    expected = %w(Methionine Phenylalanine)
+    assert_equal expected, Translation.of_rna(strand)
+  end
+
+  def test_stops_translation_of_longer_strand
+    # skip
+    strand = 'UGGUGUUAUUAAUGGUUU'
+    expected = %w(Tryptophan Cysteine Tyrosine)
+    assert_equal expected, Translation.of_rna(strand)
+  end
+
+  def test_invalid_codons
+    # skip
+    strand = 'CARROT'
+    assert_raises('InvalidCodonError') do
+      Translation.of_rna(strand)
+    end
+  end
+end


### PR DESCRIPTION
Translate RNA sequences into proteins.

RNA can be broken into three nucleotide sequences called codons, and then translated to a polypeptide like so:

RNA: "AUGUUUUCU" => translates to

Codons: "AUG", "UUU", "UCU" => which become a polypeptide with the following sequence =>

Protein: "Methionine", "Phenylalanine", "Serine"

There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise. If it works for one codon, the program should work for all of them. However, feel free to expand the list in the test suite to include them all.

There are also three terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.

All subsequent codons after are ignored, like this:

RNA: "AUGUUUUCUUAAAUG" =>

Codons: "AUG", "UUU", "UCU", "UAA", "AUG" =>

Protein: "Methionine", "Phenylalanine", "Serine"

Note the stop codon "UAA" terminates the translation and the final methionine is not translated into the protein sequence.

Below are the codons and resulting Amino Acids needed for the exercise.


Codon | Protein
-- | --
AUG | Methionine
UUU, UUC | Phenylalanine
UUA, UUG | Leucine
UCU, UCC, UCA, UCG | Serine
UAU, UAC | Tyrosine
UGU, UGC | Cysteine
UGG | Tryptophan
UAA, UAG, UGA | STOP