### PR TITLE
Armstrong Numbers

### DIFF
--- a/ruby/armstrong-numbers/.exercism/metadata.json
+++ b/ruby/armstrong-numbers/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"ruby","exercise":"armstrong-numbers","id":"a443e729fa8d410e8ceba59960ea89dc","url":"https://exercism.io/my/solutions/a443e729fa8d410e8ceba59960ea89dc","handle":"n-flint","is_requester":true,"auto_approve":false}

--- a/ruby/armstrong-numbers/README.md
+++ b/ruby/armstrong-numbers/README.md
@@ -1,0 +1,42 @@
+# Armstrong Numbers
+
+An [Armstrong number](https://en.wikipedia.org/wiki/Narcissistic_number) is a number that is the sum of its own digits each raised to the power of the number of digits.
+
+For example:
+
+- 9 is an Armstrong number, because `9 = 9^1 = 9`
+- 10 is *not* an Armstrong number, because `10 != 1^2 + 0^2 = 1`
+- 153 is an Armstrong number, because: `153 = 1^3 + 5^3 + 3^3 = 1 + 125 + 27 = 153`
+- 154 is *not* an Armstrong number, because: `154 != 1^3 + 5^3 + 4^3 = 1 + 125 + 64 = 190`
+
+Write some code to determine whether a number is an Armstrong number.
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby armstrong_numbers_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride armstrong_numbers_test.rb
+
+
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Narcissistic_number](https://en.wikipedia.org/wiki/Narcissistic_number)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/ruby/armstrong-numbers/armstrong_numbers.rb
+++ b/ruby/armstrong-numbers/armstrong_numbers.rb
@@ -1,0 +1,10 @@
+class ArmstrongNumbers
+
+  def self.include?(input)
+    x = []
+    input.to_s.each_char do |d|
+      x << d.to_i ** input.to_s.length
+    end
+    true if x.sum == input
+  end
+end

--- a/ruby/armstrong-numbers/armstrong_numbers_test.rb
+++ b/ruby/armstrong-numbers/armstrong_numbers_test.rb
@@ -1,0 +1,50 @@
+require 'minitest/autorun'
+require_relative 'armstrong_numbers'
+
+# Common test data version: 1.1.0 b3c2522
+class ArmstrongNumbersTest < Minitest::Test
+  def test_zero_is_an_armstrong_number
+    # skip
+    assert ArmstrongNumbers.include?(0)
+  end
+
+  def test_single_digit_numbers_are_armstrong_numbers
+    # skip
+    assert ArmstrongNumbers.include?(5)
+  end
+
+  def test_there_are_no_2_digit_armstrong_numbers
+    # skip
+    refute ArmstrongNumbers.include?(10)
+  end
+
+  def test_three_digit_number_that_is_an_armstrong_number
+    # skip
+    assert ArmstrongNumbers.include?(153)
+  end
+
+  def test_three_digit_number_that_is_not_an_armstrong_number
+    # skip
+    refute ArmstrongNumbers.include?(100)
+  end
+
+  def test_four_digit_number_that_is_an_armstrong_number
+    # skip
+    assert ArmstrongNumbers.include?(9_474)
+  end
+
+  def test_four_digit_number_that_is_not_an_armstrong_number
+    # skip
+    refute ArmstrongNumbers.include?(9_475)
+  end
+
+  def test_seven_digit_number_that_is_an_armstrong_number
+    # skip
+    assert ArmstrongNumbers.include?(9_926_315)
+  end
+
+  def test_seven_digit_number_that_is_not_an_armstrong_number
+    # skip
+    refute ArmstrongNumbers.include?(9_926_314)
+  end
+end


### PR DESCRIPTION
An Armstrong number is a number that is the sum of its own digits each raised to the power of the number of digits.

For example:

9 is an Armstrong number, because 9 = 9^1 = 9
10 is not an Armstrong number, because 10 != 1^2 + 0^2 = 1
153 is an Armstrong number, because: 153 = 1^3 + 5^3 + 3^3 = 1 + 125 + 27 = 153
154 is not an Armstrong number, because: 154 != 1^3 + 5^3 + 4^3 = 1 + 125 + 64 = 190
Write some code to determine whether a number is an Armstrong number.