### PR TITLE
Isbn Verifier

### DIFF
--- a/ruby/easy/isbn-verifier/.exercism/metadata.json
+++ b/ruby/easy/isbn-verifier/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"ruby","exercise":"isbn-verifier","id":"75363b62f1874cb39bf2453b4011fbc2","url":"https://exercism.io/my/solutions/75363b62f1874cb39bf2453b4011fbc2","handle":"n-flint","is_requester":true,"auto_approve":false}

--- a/ruby/easy/isbn-verifier/README.md
+++ b/ruby/easy/isbn-verifier/README.md
@@ -1,0 +1,71 @@
+# ISBN Verifier
+
+The [ISBN-10 verification process](https://en.wikipedia.org/wiki/International_Standard_Book_Number) is used to validate book identification
+numbers. These normally contain dashes and look like: `3-598-21508-8`
+
+## ISBN
+
+The ISBN-10 format is 9 digits (0 to 9) plus one check character (either a digit or an X only). In the case the check character is an X, this represents the value '10'. These may be communicated with or without hyphens, and can be checked for their validity by the following formula:
+
+```
+(x1 * 10 + x2 * 9 + x3 * 8 + x4 * 7 + x5 * 6 + x6 * 5 + x7 * 4 + x8 * 3 + x9 * 2 + x10 * 1) mod 11 == 0
+```
+
+If the result is 0, then it is a valid ISBN-10, otherwise it is invalid.
+
+## Example
+
+Let's take the ISBN-10 `3-598-21508-8`. We plug it in to the formula, and get:
+```
+(3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 2 * 6 + 1 * 5 + 5 * 4 + 0 * 3 + 8 * 2 + 8 * 1) mod 11 == 0
+```
+
+Since the result is 0, this proves that our ISBN is valid.
+
+## Task
+
+Given a string the program should check if the provided string is a valid ISBN-10.
+Putting this into place requires some thinking about preprocessing/parsing of the string prior to calculating the check digit for the ISBN.
+
+The program should be able to verify ISBN-10 both with and without separating dashes.
+
+
+## Caveats
+
+Converting from strings to numbers can be tricky in certain languages.
+Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (representing '10'). For instance `3-598-21507-X` is a valid ISBN-10.
+
+## Bonus tasks
+
+* Generate a valid ISBN-13 from the input ISBN-10 (and maybe verify it again with a derived verifier).
+
+* Generate valid ISBN, maybe even from a given starting ISBN.
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby isbn_verifier_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride isbn_verifier_test.rb
+
+
+## Source
+
+Converting a string into a number and some basic processing utilizing a relatable real world example. [https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation](https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/ruby/easy/isbn-verifier/isbn_verifier.rb
+++ b/ruby/easy/isbn-verifier/isbn_verifier.rb
@@ -1,0 +1,31 @@
+class IsbnVerifier
+# 
+  def self.valid?(input_string)
+    return false unless translate_input(input_string)
+    isbn_array = translate_input(input_string)
+    algorithm_check(isbn_array)
+  end
+
+  def self.algorithm_check(isbn)
+    maybe = []
+    counter = 10
+    isbn.each_char do |c|
+      if c == 'X'
+        maybe << (10 * counter)
+      else
+        maybe << (c.to_i * counter)
+        counter -= 1
+      end
+    end
+    return true if (maybe.sum) % 11 == 0
+  end
+
+  def self.translate_input(input)
+    stripped = input.gsub(/\-/, '')
+    return false if stripped.length != 10
+    stripped.chop.each_char do |c|
+      return false if ('0'..'9').include?(c) == false
+    end
+    stripped
+  end
+end

--- a/ruby/easy/isbn-verifier/isbn_verifier_test.rb
+++ b/ruby/easy/isbn-verifier/isbn_verifier_test.rb
@@ -1,0 +1,107 @@
+require 'minitest/autorun'
+require_relative 'isbn_verifier'
+
+# Common test data version: 2.7.0 3134243
+class IsbnVerifierTest < Minitest::Test
+  def test_valid_isbn_number
+    # skip
+    string = "3-598-21508-8"
+    assert IsbnVerifier.valid?(string), "Expected true, '#{string}' is a valid isbn"
+  end
+
+  def test_invalid_isbn_check_digit
+    # skip
+    string = "3-598-21508-9"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_valid_isbn_number_with_a_check_digit_of_10
+    # skip
+    string = "3-598-21507-X"
+    assert IsbnVerifier.valid?(string), "Expected true, '#{string}' is a valid isbn"
+  end
+
+  def test_check_digit_is_a_character_other_than_x
+    # skip
+    string = "3-598-21507-A"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_invalid_character_in_isbn
+    # skip
+    string = "3-598-P1581-X"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_x_is_only_valid_as_a_check_digit
+    # skip
+    string = "3-598-2X507-9"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_valid_isbn_without_separating_dashes
+    # skip
+    string = "3598215088"
+    assert IsbnVerifier.valid?(string), "Expected true, '#{string}' is a valid isbn"
+  end
+
+  def test_isbn_without_separating_dashes_and_x_as_check_digit
+    # skip
+    string = "359821507X"
+    assert IsbnVerifier.valid?(string), "Expected true, '#{string}' is a valid isbn"
+  end
+
+  def test_isbn_without_check_digit_and_dashes
+    # skip
+    string = "359821507"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_too_long_isbn_and_no_dashes
+    # skip
+    string = "3598215078X"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_too_short_isbn
+    # skip
+    string = "00"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_isbn_without_check_digit
+    # skip
+    string = "3-598-21507"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_check_digit_of_x_should_not_be_used_for_0
+    # skip
+    string = "3-598-21515-X"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_empty_isbn
+    # skip
+    string = ""
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_input_is_9_characters
+    # skip
+    string = "134456729"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_invalid_characters_are_not_ignored
+    # skip
+    string = "3132P34035"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_input_is_too_long_but_contains_a_valid_isbn
+    # skip
+    string = "98245726788"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+end


### PR DESCRIPTION
The ISBN-10 verification process is used to validate book identification numbers. These normally contain dashes and look like: 3-598-21508-8

ISBN
The ISBN-10 format is 9 digits (0 to 9) plus one check character (either a digit or an X only). In the case the check character is an X, this represents the value '10'. These may be communicated with or without hyphens, and can be checked for their validity by the following formula:

(x1 * 10 + x2 * 9 + x3 * 8 + x4 * 7 + x5 * 6 + x6 * 5 + x7 * 4 + x8 * 3 + x9 * 2 + x10 * 1) mod 11 == 0
If the result is 0, then it is a valid ISBN-10, otherwise it is invalid.

Example
Let's take the ISBN-10 3-598-21508-8. We plug it in to the formula, and get:

(3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 2 * 6 + 1 * 5 + 5 * 4 + 0 * 3 + 8 * 2 + 8 * 1) mod 11 == 0
Since the result is 0, this proves that our ISBN is valid.

Task
Given a string the program should check if the provided string is a valid ISBN-10. Putting this into place requires some thinking about preprocessing/parsing of the string prior to calculating the check digit for the ISBN.

The program should be able to verify ISBN-10 both with and without separating dashes.

Caveats
Converting from strings to numbers can be tricky in certain languages. Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (representing '10'). For instance 3-598-21507-X is a valid ISBN-10.