### PR TITLE
Queen Attack

### DIFF
--- a/ruby/queen-attack/.exercism/metadata.json
+++ b/ruby/queen-attack/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"ruby","exercise":"queen-attack","id":"75a992c98d4f436a9561c96763ab373f","url":"https://exercism.io/my/solutions/75a992c98d4f436a9561c96763ab373f","handle":"n-flint","is_requester":true,"auto_approve":false}

--- a/ruby/queen-attack/README.md
+++ b/ruby/queen-attack/README.md
@@ -1,0 +1,57 @@
+# Queen Attack
+
+Given the position of two queens on a chess board, indicate whether or not they
+are positioned so that they can attack each other.
+
+In the game of chess, a queen can attack pieces which are on the same
+row, column, or diagonal.
+
+A chessboard can be represented by an 8 by 8 array.
+
+So if you're told the white queen is at (2, 3) and the black queen at
+(5, 6), then you'd know you've got a set-up like so:
+
+```text
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ W _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ B _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+```
+
+You'd also be able to answer whether the queens can attack each other.
+In this case, that answer would be yes, they can, because both pieces
+share a diagonal.
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby queen_attack_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride queen_attack_test.rb
+
+
+## Source
+
+J Dalbey's Programming Practice problems [http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/ruby/queen-attack/queen_attack.rb
+++ b/ruby/queen-attack/queen_attack.rb
@@ -1,0 +1,27 @@
+class Queens
+
+  def initialize(input_positions)
+    validate_position(input_positions)
+    @white = input_positions[:white]
+    @black = input_positions[:black]
+  end
+
+  def validate_position(pos)
+    case
+    when pos[:white][0] < 0 || pos[:white][0] > 7,
+         pos[:white][1] < 0 || pos[:white][1] > 7,
+         pos[:black] && (pos[:black][0] < 0 || pos[:black][0] > 7),
+         pos[:black] && (pos[:black][1] < 0 || pos[:black][1] > 7)
+      raise ArgumentError
+    end
+  end
+
+  def attack?
+    case
+    when @white[0] == @black[0],
+         @white[1] == @black[1],
+         (@white[0] - @black[0]).abs == (@white[1] - @black[1]).abs
+      true
+    end
+  end
+end

--- a/ruby/queen-attack/queen_attack_test.rb
+++ b/ruby/queen-attack/queen_attack_test.rb
@@ -1,0 +1,80 @@
+require 'minitest/autorun'
+require_relative 'queen_attack'
+
+# Common test data version: 2.2.0 aaadbac
+class QueenAttackTest < Minitest::Test
+  def test_queen_with_a_valid_position
+    # skip
+    assert Queens.new(white: [2, 2])
+  end
+
+  def test_queen_must_have_positive_row
+    # skip
+    assert_raises(ArgumentError) do
+      Queens.new(white: [-2, 2])
+    end
+  end
+
+  def test_queen_must_have_row_on_board
+    # skip
+    assert_raises(ArgumentError) do
+      Queens.new(white: [8, 4])
+    end
+  end
+
+  def test_queen_must_have_positive_column
+    # skip
+    assert_raises(ArgumentError) do
+      Queens.new(white: [2, -2])
+    end
+  end
+
+  def test_queen_must_have_column_on_board
+    # skip
+    assert_raises(ArgumentError) do
+      Queens.new(white: [4, 8])
+    end
+  end
+
+  def test_can_not_attack
+    # skip
+    queens = Queens.new(white: [2, 4], black: [6, 6])
+    refute queens.attack?
+  end
+
+  def test_can_attack_on_same_row
+    # skip
+    queens = Queens.new(white: [2, 4], black: [2, 6])
+    assert queens.attack?
+  end
+
+  def test_can_attack_on_same_column
+    # skip
+    queens = Queens.new(white: [4, 5], black: [2, 5])
+    assert queens.attack?
+  end
+
+  def test_can_attack_on_first_diagonal
+    # skip
+    queens = Queens.new(white: [2, 2], black: [0, 4])
+    assert queens.attack?
+  end
+
+  def test_can_attack_on_second_diagonal
+    # skip
+    queens = Queens.new(white: [2, 2], black: [3, 1])
+    assert queens.attack?
+  end
+
+  def test_can_attack_on_third_diagonal
+    # skip
+    queens = Queens.new(white: [2, 2], black: [1, 1])
+    assert queens.attack?
+  end
+
+  def test_can_attack_on_fourth_diagonal
+    # skip
+    queens = Queens.new(white: [2, 2], black: [5, 5])
+    assert queens.attack?
+  end
+end


### PR DESCRIPTION
Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.

In the game of chess, a queen can attack pieces which are on the same row, column, or diagonal.

A chessboard can be represented by an 8 by 8 array.

So if you're told the white queen is at (2, 3) and the black queen at (5, 6), then you'd know you've got a set-up like so:

_ _ _ _ _ _ _ _
_ _ _ _ _ _ _ _
_ _ _ W _ _ _ _
_ _ _ _ _ _ _ _
_ _ _ _ _ _ _ _
_ _ _ _ _ _ B _
_ _ _ _ _ _ _ _
_ _ _ _ _ _ _ _
You'd also be able to answer whether the queens can attack each other. In this case, that answer would be yes, they can, because both pieces share a diagonal.